### PR TITLE
deps: Update `num` from 0.2 to 0.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-num = "0.2"
+num = "0.4"
 derive_builder = "0.7"
 serde = { version = "1.0.152", features = ["derive"], optional=true}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@
 
 #[macro_use]
 extern crate derive_builder;
-extern crate num;
 
 pub mod area;
 pub mod entry;


### PR DESCRIPTION
Also, since this crate is on 2018 edition, don't use `extern crate` to reference it.