### PR TITLE
Set builder(setter(into)) on Area.anchor

### DIFF
--- a/src/area.rs
+++ b/src/area.rs
@@ -37,6 +37,7 @@ pub struct Area<U>
 where
     U: PrimInt + Default + PartialOrd,
 {
+    #[builder(setter(into))]
     anchor: point::Point<U>,
     #[builder(default = "(U::one(), U::one())")]
     dimensions: (U, U),

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -39,7 +39,7 @@ use {
 ///
 /// let mut qt = Quadtree::<u32, f64>::new(4);
 /// let region_a = AreaBuilder::default()
-///     .anchor((1, 1).into())
+///     .anchor((1, 1))
 ///     .dimensions((3, 2))
 ///     .build().unwrap();
 ///
@@ -48,7 +48,7 @@ use {
 /// // Calling Quadtree::delete() on a region in the tree clears that region of the tree and returns the region/value associations which were deleted.
 ///
 /// let region_b = AreaBuilder::default()
-///     .anchor((2, 1).into())
+///     .anchor((2, 1))
 ///     .build().unwrap();
 ///
 /// // The iterator contains Entry<U, V> structs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,13 +404,13 @@ where
     /// let mut qt = Quadtree::<u32, char>::new(4);
     ///
     /// let region_a = AreaBuilder::default()
-    ///     .anchor((2, 1).into())
+    ///     .anchor((2, 1))
     ///     .dimensions((3, 2))
     ///     .build().unwrap();
     /// qt.insert(region_a, 'a');
     ///
     /// let region_b = AreaBuilder::default()
-    ///     .anchor((1, 4).into())
+    ///     .anchor((1, 4))
     ///     .dimensions((3, 1))
     ///     .build().unwrap();
     /// qt.insert(region_b, 'b');
@@ -423,7 +423,7 @@ where
     /// // 4 ░▒▒▒░░░
     /// // 5 ░░░░░░░
     /// let region_c = AreaBuilder::default()
-    ///     .anchor((2, 1).into()).build().unwrap();
+    ///     .anchor((2, 1)).build().unwrap();
     /// let mut query_a = qt.query(region_c);
     ///
     /// // We can use the Entry API to destructure the result.
@@ -442,7 +442,7 @@ where
     /// // 4 ░▓▓▓▒▒░
     /// // 5 ░░░░░░░
     /// let region_d = AreaBuilder::default()
-    ///     .anchor((1, 1).into())
+    ///     .anchor((1, 1))
     ///     .dimensions((4, 4))
     ///     .build().unwrap();
     /// let query_b = qt.query(region_d);
@@ -475,7 +475,7 @@ where
     /// let mut qt = Quadtree::<u8, bool>::new(3);
     ///
     /// let region_a = AreaBuilder::default()
-    ///     .anchor((0, 0).into())
+    ///     .anchor((0, 0))
     ///     .build().unwrap();
     /// let handle = qt.insert(region_a, true).unwrap();
     ///
@@ -531,13 +531,13 @@ where
     /// let mut qt = Quadtree::<u32, f64>::new(4);
     ///
     /// let region_a = AreaBuilder::default()
-    ///     .anchor((0, 0).into())
+    ///     .anchor((0, 0))
     ///     .dimensions((2, 2))
     ///     .build().unwrap();
     /// qt.insert(region_a, 1.23);
     ///
     /// let region_b = AreaBuilder::default()
-    ///     .anchor((1, 1).into())
+    ///     .anchor((1, 1))
     ///     .dimensions((3, 2))
     ///     .build().unwrap();
     /// qt.insert(region_b, 4.56);
@@ -548,7 +548,7 @@ where
     /// // 2  ░░░
     ///
     /// let region_c = AreaBuilder::default()
-    ///     .anchor((2, 1).into()).build().unwrap();
+    ///     .anchor((2, 1)).build().unwrap();
     /// let mut returned_entries = qt.delete(region_c);
     ///
     /// // We've removed one object from the quadtree.

--- a/tests/area_tests.rs
+++ b/tests/area_tests.rs
@@ -21,7 +21,7 @@ mod area_tests {
         #[test]
         fn builder() {
             let a: Area<i8> = AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((2, 2))
                 .build()
                 .unwrap();
@@ -33,7 +33,7 @@ mod area_tests {
     fn bad_dims() {
         for dims in [(-1, 4), (1, -4), (0, 4), (1, 0)].iter() {
             debug_assert!(AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions(*dims)
                 .build()
                 .is_err());
@@ -43,14 +43,14 @@ mod area_tests {
     #[test]
     fn point_in_all_quadrants() {
         for p in [(1, 1), (-1, 1), (1, -1), (-1, -1)].iter() {
-            let _a: Area<i8> = AreaBuilder::default().anchor(p.into()).build().unwrap();
+            let _a: Area<i8> = AreaBuilder::default().anchor(p).build().unwrap();
         }
     }
 
     #[test]
     fn properties() {
         let a = AreaBuilder::default()
-            .anchor((3, 4).into())
+            .anchor((3, 4))
             .dimensions((5, 7))
             .build()
             .unwrap();
@@ -82,7 +82,7 @@ mod area_tests {
 
         fn test_area() -> Area<u8> {
             AreaBuilder::default()
-                .anchor((1, 1).into())
+                .anchor((1, 1))
                 .dimensions((2, 2))
                 .build()
                 .unwrap()
@@ -94,28 +94,28 @@ mod area_tests {
 
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 2).into())
+                    .anchor((1, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 1).into())
+                    .anchor((2, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
@@ -128,7 +128,7 @@ mod area_tests {
 
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -141,112 +141,112 @@ mod area_tests {
 
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 0).into())
+                    .anchor((1, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 0).into())
+                    .anchor((2, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((3, 0).into())
+                    .anchor((3, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((4, 0).into())
+                    .anchor((4, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 3).into())
+                    .anchor((0, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 3).into())
+                    .anchor((1, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 3).into())
+                    .anchor((2, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((4, 3).into())
+                    .anchor((4, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 1).into())
+                    .anchor((0, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 2).into())
+                    .anchor((0, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 3).into())
+                    .anchor((0, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((3, 1).into())
+                    .anchor((3, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((3, 2).into())
+                    .anchor((3, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
@@ -259,14 +259,14 @@ mod area_tests {
 
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -279,28 +279,28 @@ mod area_tests {
 
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 0).into())
+                    .anchor((1, 0))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
@@ -349,7 +349,7 @@ mod area_tests {
 
         fn test_area() -> Area<i8> {
             AreaBuilder::default()
-                .anchor((-1, -1).into())
+                .anchor((-1, -1))
                 .dimensions((2, 2))
                 .build()
                 .unwrap()
@@ -361,28 +361,28 @@ mod area_tests {
 
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((-1, -1).into())
+                    .anchor((-1, -1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((0, -1).into())
+                    .anchor((0, -1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((-1, 0).into())
+                    .anchor((-1, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
@@ -395,7 +395,7 @@ mod area_tests {
 
             debug_assert!(a.contains(
                 AreaBuilder::default()
-                    .anchor((-1, -1).into())
+                    .anchor((-1, -1))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -408,112 +408,112 @@ mod area_tests {
 
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-2, -2).into())
+                    .anchor((-2, -2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-2, -1).into())
+                    .anchor((-2, -1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-2, 0).into())
+                    .anchor((-2, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-2, 1).into())
+                    .anchor((-2, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-2, 2).into())
+                    .anchor((-2, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-1, 2).into())
+                    .anchor((-1, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 2).into())
+                    .anchor((0, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 2).into())
+                    .anchor((1, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 1).into())
+                    .anchor((2, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 0).into())
+                    .anchor((2, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, -1).into())
+                    .anchor((2, -1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, -2).into())
+                    .anchor((2, -2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((1, -2).into())
+                    .anchor((1, -2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, -2).into())
+                    .anchor((0, -2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-1, -2).into())
+                    .anchor((-1, -2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
@@ -526,21 +526,21 @@ mod area_tests {
 
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-2, -2).into())
+                    .anchor((-2, -2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -553,42 +553,42 @@ mod area_tests {
 
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((1, 0).into())
+                    .anchor((1, 0))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-1, -1).into())
+                    .anchor((-1, -1))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-1, 1).into())
+                    .anchor((-1, 1))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-2, 1).into())
+                    .anchor((-2, 1))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.contains(
                 AreaBuilder::default()
-                    .anchor((-2, -2).into())
+                    .anchor((-2, -2))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
@@ -646,7 +646,7 @@ mod area_tests {
 
         fn test_area() -> Area<u8> {
             AreaBuilder::default()
-                .anchor((2, 2).into())
+                .anchor((2, 2))
                 .dimensions((2, 2))
                 .build()
                 .unwrap()
@@ -659,28 +659,28 @@ mod area_tests {
 
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((2, 3).into())
+                    .anchor((2, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((3, 2).into())
+                    .anchor((3, 2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
@@ -694,7 +694,7 @@ mod area_tests {
 
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -708,91 +708,91 @@ mod area_tests {
 
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((2, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((4, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((2, 1).into())
+                    .anchor((2, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((3, 1).into())
+                    .anchor((3, 1))
                     .dimensions((2, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((4, 1).into())
+                    .anchor((4, 1))
                     .dimensions((2, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((1, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 2).into())
+                    .anchor((1, 2))
                     .dimensions((1, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 3).into())
+                    .anchor((1, 3))
                     .dimensions((1, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 4).into())
+                    .anchor((1, 4))
                     .dimensions((1, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((2, 4).into())
+                    .anchor((2, 4))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((3, 4).into())
+                    .anchor((3, 4))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((4, 4).into())
+                    .anchor((4, 4))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
@@ -806,28 +806,28 @@ mod area_tests {
 
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 3).into())
+                    .anchor((1, 3))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -837,12 +837,12 @@ mod area_tests {
         #[test]
         fn regression_test() {
             let a: Area<u8> = AreaBuilder::default()
-                .anchor((3, 3).into())
+                .anchor((3, 3))
                 .dimensions((2, 2))
                 .build()
                 .unwrap();
             let b: Area<u8> = AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((6, 6))
                 .build()
                 .unwrap();
@@ -873,7 +873,7 @@ mod area_tests {
 
         fn test_area() -> Area<i8> {
             AreaBuilder::default()
-                .anchor((-1, -1).into())
+                .anchor((-1, -1))
                 .dimensions((2, 2))
                 .build()
                 .unwrap()
@@ -884,28 +884,28 @@ mod area_tests {
             let a = test_area();
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((-1, -1).into())
+                    .anchor((-1, -1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((-1, 0).into())
+                    .anchor((-1, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((0, -1).into())
+                    .anchor((0, -1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
@@ -917,7 +917,7 @@ mod area_tests {
             let a = test_area();
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((-1, -1).into())
+                    .anchor((-1, -1))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -929,28 +929,28 @@ mod area_tests {
             let a = test_area();
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((-2, -2).into())
+                    .anchor((-2, -2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((0, -2).into())
+                    .anchor((0, -2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
             ));
             debug_assert!(a.intersects(
                 AreaBuilder::default()
-                    .anchor((-2, 0).into())
+                    .anchor((-2, 0))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -962,35 +962,35 @@ mod area_tests {
             let a = test_area();
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, -1).into())
+                    .anchor((1, -1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((-1, 1).into())
+                    .anchor((-1, 1))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((-2, 0).into())
+                    .anchor((-2, 0))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()
             ));
             debug_assert!(!a.intersects(
                 AreaBuilder::default()
-                    .anchor((-2, -2).into())
+                    .anchor((-2, -2))
                     .dimensions((1, 1))
                     .build()
                     .unwrap()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -75,7 +75,7 @@ mod insert {
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((2, 3))
                     .build()
                     .unwrap(),
@@ -83,20 +83,14 @@ mod insert {
             )
             .is_some());
         assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((1, 1).into())
-                    .build()
-                    .unwrap(),
-                3,
-            )
+            .insert(AreaBuilder::default().anchor((1, 1)).build().unwrap(), 3,)
             .is_some());
 
         // The full bounds of the region.
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((4, 4))
                     .build()
                     .unwrap(),
@@ -105,13 +99,7 @@ mod insert {
             .is_some());
         // At (3, 3) but 1x1
         assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((3, 3).into())
-                    .build()
-                    .unwrap(),
-                19,
-            )
+            .insert(AreaBuilder::default().anchor((3, 3)).build().unwrap(), 19,)
             .is_some());
     }
 
@@ -122,7 +110,7 @@ mod insert {
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((5, 5))
                     .build()
                     .unwrap(),
@@ -132,25 +120,13 @@ mod insert {
 
         // At (4, 4) but 1x1.
         assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((4, 4).into())
-                    .build()
-                    .unwrap(),
-                20,
-            )
+            .insert(AreaBuilder::default().anchor((4, 4)).build().unwrap(), 20,)
             .is_none());
 
         // Since the region overlaps, insertion fails.
         let mut qt = Quadtree::<u32, u16>::new_with_anchor((2, 2).into(), 2);
         assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap(),
-                25,
-            )
+            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 25,)
             .is_none());
     }
 }
@@ -160,35 +136,17 @@ fn len() {
     let mut qt = Quadtree::<u32, u32>::new(4);
     debug_assert_eq!(qt.len(), 0);
     assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
-            2,
-        )
+        .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 2,)
         .is_some());
     debug_assert_eq!(qt.len(), 1);
     // Even if it's the same thing again.
     assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
-            2,
-        )
+        .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 2,)
         .is_some());
     debug_assert_eq!(qt.len(), 2);
     // Or if it's a point.
     assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((2, 3).into())
-                .build()
-                .unwrap(),
-            2,
-        )
+        .insert(AreaBuilder::default().anchor((2, 3)).build().unwrap(), 2,)
         .is_some());
     debug_assert_eq!(qt.len(), 3);
 }
@@ -201,7 +159,7 @@ fn fill_quadrant() {
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -215,7 +173,7 @@ fn fill_quadrant() {
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((2, 2).into())
+                .anchor((2, 2))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -235,7 +193,7 @@ fn is_empty() {
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -249,13 +207,7 @@ fn is_empty() {
 
     // Insert point
     assert!(q2
-        .insert(
-            AreaBuilder::default()
-                .anchor((1, 1).into())
-                .build()
-                .unwrap(),
-            50,
-        )
+        .insert(AreaBuilder::default().anchor((1, 1)).build().unwrap(), 50,)
         .is_some());
     debug_assert!(!q2.is_empty());
 }
@@ -267,10 +219,7 @@ fn reset() {
 
     assert!(qt
         .insert(
-            AreaBuilder::default()
-                .anchor((2, 2).into())
-                .build()
-                .unwrap(),
+            AreaBuilder::default().anchor((2, 2)).build().unwrap(),
             57.27,
         )
         .is_some());
@@ -290,20 +239,12 @@ mod string {
         let mut qt = Quadtree::<u32, String>::new(4);
         assert!(qt
             .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap(),
+                AreaBuilder::default().anchor((0, 0)).build().unwrap(),
                 "foo_bar_baz".to_string(),
             )
             .is_some());
 
-        let mut iter = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
-        );
+        let mut iter = qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap());
         assert_eq!(iter.next().unwrap().value_ref(), "foo_bar_baz");
     }
 
@@ -312,31 +253,20 @@ mod string {
         let mut qt = Quadtree::<u32, String>::new(4);
         assert!(qt
             .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap(),
+                AreaBuilder::default().anchor((0, 0)).build().unwrap(),
                 "hello ".to_string(),
             )
             .is_some());
         qt.modify(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
+            AreaBuilder::default().anchor((0, 0)).build().unwrap(),
             |v| *v += "world",
         );
 
         assert_eq!(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
+                .next()
+                .unwrap()
+                .value_ref(),
             "hello world"
         );
     }
@@ -358,26 +288,15 @@ fn quadtree_struct() {
     let mut qt = Quadtree::<u32, Foo>::new(4);
 
     assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
-            foo,
-        )
+        .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), foo,)
         .is_some());
 
     assert_eq!(
-        qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap()
-        )
-        .next()
-        .unwrap()
-        .value_ref()
-        .baz,
+        qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
+            .next()
+            .unwrap()
+            .value_ref()
+            .baz,
         "baz"
     );
 }
@@ -397,12 +316,7 @@ mod extend {
         debug_assert_eq!(qt.len(), 2);
 
         let entry_zero = qt
-            .query(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap(),
-            )
+            .query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
             .next()
             .unwrap();
         let area_zero = entry_zero.area();
@@ -413,12 +327,7 @@ mod extend {
         debug_assert_eq!(entry_zero.value_ref(), &0);
 
         let entry_five = qt
-            .query(
-                AreaBuilder::default()
-                    .anchor((2, 3).into())
-                    .build()
-                    .unwrap(),
-            )
+            .query(AreaBuilder::default().anchor((2, 3)).build().unwrap())
             .next()
             .unwrap();
         let area_five = entry_five.area();
@@ -435,18 +344,12 @@ mod extend {
         assert!(qt.is_empty());
 
         assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap(),
-                0,
-            )
+            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 0,)
             .is_some());
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((2, 3).into())
+                    .anchor((2, 3))
                     .dimensions((3, 4))
                     .build()
                     .unwrap(),
@@ -457,27 +360,17 @@ mod extend {
         debug_assert_eq!(qt.len(), 2);
 
         debug_assert_eq!(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
+                .next()
+                .unwrap()
+                .value_ref(),
             &0
         );
         debug_assert_eq!(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((2, 3).into())
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query(AreaBuilder::default().anchor((2, 3)).build().unwrap())
+                .next()
+                .unwrap()
+                .value_ref(),
             &5
         );
     }
@@ -495,13 +388,7 @@ mod delete {
 
         // But we will be sure to retain this one.
         let handle = qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap(),
-                11,
-            )
+            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 11)
             .unwrap();
         debug_assert_eq!(qt.len(), 5); // Insertion succeeded.
 
@@ -519,13 +406,8 @@ mod delete {
 
         // And, check that queries over the previous area don't crash or return garbage indices.
         debug_assert_eq!(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap()
-            )
-            .count(),
+            qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
+                .count(),
             1
         );
     }
@@ -538,7 +420,7 @@ fn debug() {
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -546,18 +428,12 @@ fn debug() {
         )
         .is_some());
     assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((1, 1).into())
-                .build()
-                .unwrap(),
-            2.46,
-        )
+        .insert(AreaBuilder::default().anchor((1, 1)).build().unwrap(), 2.46,)
         .is_some());
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((1, 1).into())
+                .anchor((1, 1))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -567,7 +443,7 @@ fn debug() {
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((2, 2).into())
+                .anchor((2, 2))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -586,7 +462,7 @@ fn test_print_quadtree() {
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -594,18 +470,12 @@ fn test_print_quadtree() {
         )
         .is_some());
     assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((2, 3).into())
-                .build()
-                .unwrap(),
-            2.46,
-        )
+        .insert(AreaBuilder::default().anchor((2, 3)).build().unwrap(), 2.46,)
         .is_some());
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((1, 1).into())
+                .anchor((1, 1))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -615,7 +485,7 @@ fn test_print_quadtree() {
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((2, 2).into())
+                .anchor((2, 2))
                 .dimensions((4, 4))
                 .build()
                 .unwrap(),
@@ -625,7 +495,7 @@ fn test_print_quadtree() {
     assert!(qt
         .insert(
             AreaBuilder::default()
-                .anchor((0, 4).into())
+                .anchor((0, 4))
                 .dimensions((2, 3))
                 .build()
                 .unwrap(),

--- a/tests/iterator_tests.rs
+++ b/tests/iterator_tests.rs
@@ -85,7 +85,7 @@ mod iterator_tests {
         debug_assert_eq!(qt.len(), 3);
         qt.delete(
             AreaBuilder::default()
-                .anchor((-35, -35).into())
+                .anchor((-35, -35))
                 .dimensions((80, 80))
                 .build()
                 .unwrap(),
@@ -98,30 +98,18 @@ mod iterator_tests {
         let mut qt = mk_quadtree_for_iter_tests();
         debug_assert_eq!(qt.len(), 3);
         // Near miss.
-        qt.delete(
-            AreaBuilder::default()
-                .anchor((29, -36).into())
-                .build()
-                .unwrap(),
-        );
+        qt.delete(AreaBuilder::default().anchor((29, -36)).build().unwrap());
         debug_assert_eq!(qt.len(), 3);
 
         // Direct hit!
-        let mut returned_entries = qt.delete(
-            AreaBuilder::default()
-                .anchor((30, -35).into())
-                .build()
-                .unwrap(),
-        );
+        let mut returned_entries =
+            qt.delete(AreaBuilder::default().anchor((30, -35)).build().unwrap());
         debug_assert_eq!(qt.len(), 2);
         let hit = returned_entries.next().unwrap();
         debug_assert_eq!(hit.value_ref(), &40);
         debug_assert_eq!(
             hit.area(),
-            AreaBuilder::default()
-                .anchor((30, -35).into())
-                .build()
-                .unwrap()
+            AreaBuilder::default().anchor((30, -35)).build().unwrap()
         );
     }
 
@@ -134,7 +122,7 @@ mod iterator_tests {
         let returned_entries: Vec<Entry<i32, i8>> = qt
             .delete(
                 AreaBuilder::default()
-                    .anchor((-15, -5).into())
+                    .anchor((-15, -5))
                     .dimensions((16, 26))
                     .build()
                     .unwrap(),

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -26,7 +26,7 @@ mod query_tests {
         let qt = Quadtree::<u32, u8>::new(2);
         let mut iter = qt.query(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((4, 4))
                 .build()
                 .unwrap(),
@@ -38,22 +38,11 @@ mod query_tests {
     fn query_on_point() {
         let mut qt = Quadtree::<u32, u8>::new(1);
         assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap(),
-                49,
-            )
+            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 49,)
             .is_some());
 
         // Requesting a region which does contain '49'.
-        let mut iter1 = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
-        );
+        let mut iter1 = qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap());
         let entry = iter1.next().unwrap();
         let entry_area = entry.area();
 
@@ -66,28 +55,13 @@ mod query_tests {
         debug_assert_eq!(iter1.next(), None);
 
         // Requesting regions which don't contain '49'.
-        let mut iter2 = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 1).into())
-                .build()
-                .unwrap(),
-        );
+        let mut iter2 = qt.query(AreaBuilder::default().anchor((0, 1)).build().unwrap());
         debug_assert_eq!(iter2.next(), None);
 
-        let mut iter3 = qt.query(
-            AreaBuilder::default()
-                .anchor((1, 0).into())
-                .build()
-                .unwrap(),
-        );
+        let mut iter3 = qt.query(AreaBuilder::default().anchor((1, 0)).build().unwrap());
         debug_assert_eq!(iter3.next(), None);
 
-        let mut iter4 = qt.query(
-            AreaBuilder::default()
-                .anchor((1, 1).into())
-                .build()
-                .unwrap(),
-        );
+        let mut iter4 = qt.query(AreaBuilder::default().anchor((1, 1)).build().unwrap());
         debug_assert_eq!(iter4.next(), None);
     }
 
@@ -111,7 +85,7 @@ mod query_tests {
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap(),
@@ -121,7 +95,7 @@ mod query_tests {
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((2, 2))
                     .build()
                     .unwrap(),
@@ -130,17 +104,12 @@ mod query_tests {
             .is_some());
 
         // Queries which turn up empty:
-        let mut empty1 = qt.query(
-            AreaBuilder::default()
-                .anchor((1, 1).into())
-                .build()
-                .unwrap(),
-        );
+        let mut empty1 = qt.query(AreaBuilder::default().anchor((1, 1)).build().unwrap());
         debug_assert_eq!(empty1.next(), None);
 
         let mut empty2 = qt.query(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -149,7 +118,7 @@ mod query_tests {
 
         let mut empty3 = qt.query(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((6, 2))
                 .build()
                 .unwrap(),
@@ -158,7 +127,7 @@ mod query_tests {
 
         let mut empty4 = qt.query(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((2, 6))
                 .build()
                 .unwrap(),
@@ -166,37 +135,22 @@ mod query_tests {
         debug_assert_eq!(empty4.next(), None);
 
         // Queries which capture #10:
-        let mut ten1 = qt.query(
-            AreaBuilder::default()
-                .anchor((2, 2).into())
-                .build()
-                .unwrap(),
-        );
+        let mut ten1 = qt.query(AreaBuilder::default().anchor((2, 2)).build().unwrap());
         debug_assert_eq!(ten1.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten1.next(), None);
 
-        let mut ten2 = qt.query(
-            AreaBuilder::default()
-                .anchor((2, 3).into())
-                .build()
-                .unwrap(),
-        );
+        let mut ten2 = qt.query(AreaBuilder::default().anchor((2, 3)).build().unwrap());
         debug_assert_eq!(ten2.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten2.next(), None);
 
-        let mut ten3 = qt.query(
-            AreaBuilder::default()
-                .anchor((3, 2).into())
-                .build()
-                .unwrap(),
-        );
+        let mut ten3 = qt.query(AreaBuilder::default().anchor((3, 2)).build().unwrap());
         debug_assert_eq!(ten3.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten3.next(), None);
 
         // Queries which capture #10 but are larger than 1x1.
         let mut ten4 = qt.query(
             AreaBuilder::default()
-                .anchor((2, 2).into())
+                .anchor((2, 2))
                 .dimensions((2, 1))
                 .build()
                 .unwrap(),
@@ -204,57 +158,32 @@ mod query_tests {
         debug_assert_eq!(ten4.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten4.next(), None);
 
-        let mut ten5 = qt.query(
-            AreaBuilder::default()
-                .anchor((2, 2).into())
-                .build()
-                .unwrap(),
-        );
+        let mut ten5 = qt.query(AreaBuilder::default().anchor((2, 2)).build().unwrap());
         debug_assert_eq!(ten5.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten5.next(), None);
 
         // Queries which capture #55:
-        let mut fiftyfive1 = qt.query(
-            AreaBuilder::default()
-                .anchor((3, 4).into())
-                .build()
-                .unwrap(),
-        );
+        let mut fiftyfive1 = qt.query(AreaBuilder::default().anchor((3, 4)).build().unwrap());
         debug_assert_eq!(fiftyfive1.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive1.next(), None);
 
-        let mut fiftyfive2 = qt.query(
-            AreaBuilder::default()
-                .anchor((4, 3).into())
-                .build()
-                .unwrap(),
-        );
+        let mut fiftyfive2 = qt.query(AreaBuilder::default().anchor((4, 3)).build().unwrap());
         debug_assert_eq!(fiftyfive2.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive2.next(), None);
 
-        let mut fiftyfive3 = qt.query(
-            AreaBuilder::default()
-                .anchor((4, 4).into())
-                .build()
-                .unwrap(),
-        );
+        let mut fiftyfive3 = qt.query(AreaBuilder::default().anchor((4, 4)).build().unwrap());
         debug_assert_eq!(fiftyfive3.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive3.next(), None);
 
         // Queries which capture #55 but are larger than 1x1.
 
-        let mut fiftyfive4 = qt.query(
-            AreaBuilder::default()
-                .anchor((4, 3).into())
-                .build()
-                .unwrap(),
-        );
+        let mut fiftyfive4 = qt.query(AreaBuilder::default().anchor((4, 3)).build().unwrap());
         debug_assert_eq!(fiftyfive4.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive4.next(), None);
 
         let mut fiftyfive5 = qt.query(
             AreaBuilder::default()
-                .anchor((3, 4).into())
+                .anchor((3, 4))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
@@ -265,20 +194,15 @@ mod query_tests {
         // Queries which capture both #10 and #55. Dunno in what order.
 
         debug_assert!(unordered_elements_are(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((3, 3).into())
-                    .build()
-                    .unwrap()
-            )
-            .map(|e| e.value_ref()),
+            qt.query(AreaBuilder::default().anchor((3, 3)).build().unwrap())
+                .map(|e| e.value_ref()),
             vec![&10, &55],
         ));
 
         debug_assert!(unordered_elements_are(
             qt.query(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
@@ -290,7 +214,7 @@ mod query_tests {
         debug_assert!(unordered_elements_are(
             qt.query(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((6, 6))
                     .build()
                     .unwrap()
@@ -302,7 +226,7 @@ mod query_tests {
         debug_assert!(unordered_elements_are(
             qt.query(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((6, 6))
                     .build()
                     .unwrap()
@@ -314,7 +238,7 @@ mod query_tests {
         debug_assert!(unordered_elements_are(
             qt.query(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -344,7 +268,7 @@ mod query_tests {
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap(),
@@ -354,7 +278,7 @@ mod query_tests {
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((2, 2))
                     .build()
                     .unwrap(),
@@ -364,19 +288,14 @@ mod query_tests {
 
         // Queries which turn up empty:
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((1, 1).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
+            qt.query_strict(AreaBuilder::default().anchor((1, 1)).build().unwrap())
+                .next(),
             None
         );
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -387,7 +306,7 @@ mod query_tests {
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((6, 2))
                     .build()
                     .unwrap()
@@ -398,7 +317,7 @@ mod query_tests {
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((2, 6))
                     .build()
                     .unwrap()
@@ -409,39 +328,24 @@ mod query_tests {
 
         // Queries which capture portions of #10 but not enough.
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((2, 2).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
+            qt.query_strict(AreaBuilder::default().anchor((2, 2)).build().unwrap())
+                .next(),
+            None
+        );
+        debug_assert_eq!(
+            qt.query_strict(AreaBuilder::default().anchor((2, 3)).build().unwrap())
+                .next(),
+            None
+        );
+        debug_assert_eq!(
+            qt.query_strict(AreaBuilder::default().anchor((3, 2)).build().unwrap())
+                .next(),
             None
         );
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((2, 3).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((3, 2).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((2, 1))
                     .build()
                     .unwrap()
@@ -450,61 +354,36 @@ mod query_tests {
             None
         );
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((2, 2).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
+            qt.query_strict(AreaBuilder::default().anchor((2, 2)).build().unwrap())
+                .next(),
             None
         );
 
         // Queries which capture portions of #55 but not enough.
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((3, 4).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
+            qt.query_strict(AreaBuilder::default().anchor((3, 4)).build().unwrap())
+                .next(),
+            None
+        );
+        debug_assert_eq!(
+            qt.query_strict(AreaBuilder::default().anchor((4, 3)).build().unwrap())
+                .next(),
+            None
+        );
+        debug_assert_eq!(
+            qt.query_strict(AreaBuilder::default().anchor((4, 4)).build().unwrap())
+                .next(),
+            None
+        );
+        debug_assert_eq!(
+            qt.query_strict(AreaBuilder::default().anchor((4, 3)).build().unwrap())
+                .next(),
             None
         );
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((4, 3).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((4, 4).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((4, 3).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((3, 4).into())
+                    .anchor((3, 4))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -516,13 +395,8 @@ mod query_tests {
         // Queries which capture portions of both #10 and #55. but still aren't enough
 
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((3, 3).into())
-                    .build()
-                    .unwrap()
-            )
-            .next(),
+            qt.query_strict(AreaBuilder::default().anchor((3, 3)).build().unwrap())
+                .next(),
             None
         );
 
@@ -530,7 +404,7 @@ mod query_tests {
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -543,7 +417,7 @@ mod query_tests {
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
@@ -556,7 +430,7 @@ mod query_tests {
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((3, 3).into())
+                    .anchor((3, 3))
                     .dimensions((4, 4))
                     .build()
                     .unwrap()
@@ -569,7 +443,7 @@ mod query_tests {
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((4, 4))
                     .build()
                     .unwrap()
@@ -582,7 +456,7 @@ mod query_tests {
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((1, 1).into())
+                    .anchor((1, 1))
                     .dimensions((3, 3))
                     .build()
                     .unwrap()
@@ -595,7 +469,7 @@ mod query_tests {
         debug_assert_eq!(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((2, 2))
                     .build()
                     .unwrap()
@@ -610,7 +484,7 @@ mod query_tests {
         debug_assert!(unordered_elements_are(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((6, 6))
                     .build()
                     .unwrap()
@@ -621,7 +495,7 @@ mod query_tests {
         debug_assert!(unordered_elements_are(
             qt.query_strict(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((6, 6))
                     .build()
                     .unwrap()
@@ -637,7 +511,7 @@ mod query_tests {
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((0, 0).into())
+                    .anchor((0, 0))
                     .dimensions((2, 2))
                     .build()
                     .unwrap(),
@@ -645,12 +519,7 @@ mod query_tests {
             )
             .is_some());
 
-        let mut query_obj = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
-        );
+        let mut query_obj = qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap());
 
         debug_assert_eq!(query_obj.next().unwrap().value_ref(), &1.234);
     }
@@ -661,7 +530,7 @@ mod query_tests {
         let mut qt = Quadtree::<u32, u8>::new(2);
         qt.modify(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((4, 4))
                 .build()
                 .unwrap(),
@@ -676,29 +545,15 @@ mod query_tests {
 
         // Insert #49 at (0, 0)->1x1.
         assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0).into())
-                    .build()
-                    .unwrap(),
-                49,
-            )
+            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 49,)
             .is_some());
         qt.modify(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
+            AreaBuilder::default().anchor((0, 0)).build().unwrap(),
             |i| *i += 1,
         );
 
         // And verify.
-        let mut tmp_iter_1 = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0).into())
-                .build()
-                .unwrap(),
-        );
+        let mut tmp_iter_1 = qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap());
         debug_assert_eq!(tmp_iter_1.next().unwrap().value_ref(), &50);
         debug_assert_eq!(tmp_iter_1.next(), None);
 
@@ -706,7 +561,7 @@ mod query_tests {
         assert!(qt
             .insert(
                 AreaBuilder::default()
-                    .anchor((2, 2).into())
+                    .anchor((2, 2))
                     .dimensions((3, 3))
                     .build()
                     .unwrap(),
@@ -717,26 +572,21 @@ mod query_tests {
         // Up it to 18,
         qt.modify(
             AreaBuilder::default()
-                .anchor((1, 1).into())
+                .anchor((1, 1))
                 .dimensions((2, 2))
                 .build()
                 .unwrap(),
             |i| *i += 1,
         );
         // And verify.
-        let mut tmp_iter_2 = qt.query(
-            AreaBuilder::default()
-                .anchor((2, 2).into())
-                .build()
-                .unwrap(),
-        );
+        let mut tmp_iter_2 = qt.query(AreaBuilder::default().anchor((2, 2)).build().unwrap());
         debug_assert_eq!(tmp_iter_2.next().unwrap().value_ref(), &18);
         debug_assert_eq!(tmp_iter_2.next(), None);
 
         // Reset everything in (0, 0)->6x6 to "0".
         qt.modify(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((6, 6))
                 .build()
                 .unwrap(),
@@ -746,7 +596,7 @@ mod query_tests {
 
         for entry in qt.query(
             AreaBuilder::default()
-                .anchor((0, 0).into())
+                .anchor((0, 0))
                 .dimensions((6, 6))
                 .build()
                 .unwrap(),

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -38,7 +38,7 @@ where
             match qt
                 .query(
                     AreaBuilder::default()
-                        .anchor((U::from_usize(i).unwrap(), U::from_usize(j).unwrap()).into())
+                        .anchor((U::from_usize(i).unwrap(), U::from_usize(j).unwrap()))
                         .build()
                         .unwrap(),
                 )


### PR DESCRIPTION
This lets us remove hundreds of .into() calls.