### PR TITLE
Impl From<(P, (U,U))> and From<P> for Area.

### DIFF
--- a/src/area.rs
+++ b/src/area.rs
@@ -137,7 +137,8 @@ where
     }
 
     /// Whether or not an area intersects another area.
-    pub fn intersects(self, other: Self) -> bool {
+    pub fn intersects(self, other: impl Into<Self>) -> bool {
+        let other = other.into();
         self.left_edge() < other.right_edge()
             && self.right_edge() > other.left_edge()
             && self.top_edge() < other.bottom_edge()
@@ -145,7 +146,8 @@ where
     }
 
     /// Whether or not an area wholly contains another area.
-    pub fn contains(self, other: Self) -> bool {
+    pub fn contains(self, other: impl Into<Self>) -> bool {
+        let other = other.into();
         other.right_edge() <= self.right_edge()
             && other.left_edge() >= self.left_edge()
             && other.top_edge() >= self.top_edge()
@@ -180,5 +182,29 @@ where
     // Strongly-typed alias for U::one() + U::One()
     fn two() -> U {
         U::one() + U::one()
+    }
+}
+
+impl<P, U> From<(P, (U, U))> for Area<U>
+where
+    P: Into<point::Point<U>>,
+    U: PrimInt + Default + PartialOrd,
+{
+    fn from((anchor, dimensions): (P, (U, U))) -> Self {
+        AreaBuilder::default()
+            .anchor(anchor)
+            .dimensions(dimensions)
+            .build()
+            .unwrap()
+    }
+}
+
+impl<P, U> From<P> for Area<U>
+where
+    P: Into<point::Point<U>>,
+    U: PrimInt + Default + PartialOrd,
+{
+    fn from(anchor: P) -> Self {
+        AreaBuilder::default().anchor(anchor).build().unwrap()
     }
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -33,23 +33,18 @@ use {
 /// [`.delete()`]: ../struct.Quadtree.html#method.delete
 /// ```
 /// use quadtree_rs::{
-///   area::AreaBuilder,
+///   area::Area,
 ///   Quadtree,
 /// };
 ///
 /// let mut qt = Quadtree::<u32, f64>::new(4);
-/// let region_a = AreaBuilder::default()
-///     .anchor((1, 1))
-///     .dimensions((3, 2))
-///     .build().unwrap();
+/// let region_a: Area<u32> = ((1,1),(3,2)).into();
 ///
 /// qt.insert(region_a, 4.56_f64);
 ///
 /// // Calling Quadtree::delete() on a region in the tree clears that region of the tree and returns the region/value associations which were deleted.
 ///
-/// let region_b = AreaBuilder::default()
-///     .anchor((2, 1))
-///     .build().unwrap();
+/// let region_b: Area<u32> = (2,1).into();
 ///
 /// // The iterator contains Entry<U, V> structs.
 /// let mut returned_entries = qt.delete(region_b);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -129,7 +129,7 @@ where
     U: PrimInt + Default,
 {
     pub(crate) fn new(
-        query_region: Area<U>,
+        query_region: impl Into<Area<U>>,
         qt: &'a QTInner<U>,
         store: &'a StoreType<U, V>,
         traversal_method: Traversal,
@@ -137,6 +137,8 @@ where
     where
         U: PrimInt + Default,
     {
+        let query_region = query_region.into();
+
         // Construct the HandleIter first...
         let mut handle_iter = HandleIter::new(qt, query_region);
 

--- a/src/qtinner.rs
+++ b/src/qtinner.rs
@@ -15,12 +15,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use {
-    crate::{
-        area::{Area, AreaBuilder},
-        entry::Entry,
-        point::Point,
-        types::StoreType,
-    },
+    crate::{area::Area, entry::Entry, point::Point, types::StoreType},
     num::PrimInt,
     std::{default::Default, fmt::Debug},
 };
@@ -78,14 +73,7 @@ where
         #[allow(clippy::cast_possible_truncation)]
         let width: U = Self::two().pow(depth as u32);
         let height: U = width;
-        Self::new_with_area(
-            AreaBuilder::default()
-                .anchor(anchor)
-                .dimensions((width, height))
-                .build()
-                .expect("Unexpected error in QTInner::new()."),
-            depth,
-        )
+        Self::new_with_area((anchor, (width, height)).into(), depth)
     }
 
     pub fn depth(&self) -> usize {
@@ -114,10 +102,11 @@ where
     // large.
     pub fn insert_val_at_region<V>(
         &mut self,
-        req: Area<U>,
+        req: impl Into<Area<U>>,
         val: V,
         store: &mut StoreType<U, V>,
     ) -> u64 {
+        let req = req.into();
         let handle = self.handle_counter;
         self.handle_counter += 1;
         store.insert(handle, Entry::new((req, val), handle));

--- a/tests/area_tests.rs
+++ b/tests/area_tests.rs
@@ -20,11 +20,7 @@ mod area_tests {
 
         #[test]
         fn builder() {
-            let a: Area<i8> = AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((2, 2))
-                .build()
-                .unwrap();
+            let a: Area<i8> = ((0, 0), (2, 2)).into();
             debug_assert_eq!(a.width(), 2);
         }
     }
@@ -43,17 +39,13 @@ mod area_tests {
     #[test]
     fn point_in_all_quadrants() {
         for p in [(1, 1), (-1, 1), (1, -1), (-1, -1)].iter() {
-            let _a: Area<i8> = AreaBuilder::default().anchor(p).build().unwrap();
+            let _a: Area<i8> = p.into();
         }
     }
 
     #[test]
     fn properties() {
-        let a = AreaBuilder::default()
-            .anchor((3, 4))
-            .dimensions((5, 7))
-            .build()
-            .unwrap();
+        let a: Area<u8> = ((3, 4), (5, 7)).into();
 
         debug_assert_eq!(a.anchor(), (3, 4).into());
         debug_assert_eq!(a.width(), 5);
@@ -81,230 +73,64 @@ mod area_tests {
         // 4 +--+--+--+--+
 
         fn test_area() -> Area<u8> {
-            AreaBuilder::default()
-                .anchor((1, 1))
-                .dimensions((2, 2))
-                .build()
-                .unwrap()
+            ((1, 1), (2, 2)).into()
         }
 
         #[test]
         fn all_component_1x1s() {
             let a = test_area();
 
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.contains(((1, 1), (1, 1))));
+            debug_assert!(a.contains(((1, 2), (1, 1))));
+            debug_assert!(a.contains(((2, 1), (1, 1))));
+            debug_assert!(a.contains(((2, 2), (1, 1))));
         }
 
         #[test]
         fn contains_self() {
             let a = test_area();
 
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.contains(((1, 1), (2, 2))));
         }
 
         #[test]
         fn no_neighboring_1x1s() {
             let a = test_area();
 
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((3, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((4, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((4, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((3, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((3, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(!a.contains(((0, 0), (1, 1))));
+            debug_assert!(!a.contains(((1, 0), (1, 1))));
+            debug_assert!(!a.contains(((2, 0), (1, 1))));
+            debug_assert!(!a.contains(((3, 0), (1, 1))));
+            debug_assert!(!a.contains(((4, 0), (1, 1))));
+            debug_assert!(!a.contains(((0, 3), (1, 1))));
+            debug_assert!(!a.contains(((1, 3), (1, 1))));
+            debug_assert!(!a.contains(((2, 3), (1, 1))));
+            debug_assert!(!a.contains(((3, 3), (1, 1))));
+            debug_assert!(!a.contains(((4, 3), (1, 1))));
+            debug_assert!(!a.contains(((0, 1), (1, 1))));
+            debug_assert!(!a.contains(((0, 2), (1, 1))));
+            debug_assert!(!a.contains(((0, 3), (1, 1))));
+            debug_assert!(!a.contains(((3, 1), (1, 1))));
+            debug_assert!(!a.contains(((3, 2), (1, 1))));
+            debug_assert!(!a.contains(((3, 3), (1, 1))));
         }
 
         #[test]
         fn no_overlapping_2x2s() {
             let a = test_area();
 
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(!a.contains(((0, 0), (2, 2))));
+            debug_assert!(!a.contains(((2, 2), (2, 2))));
         }
 
         #[test]
         fn no_overlapping_3x3s() {
             let a = test_area();
 
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 0))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(!a.contains(((0, 0), (3, 3))));
+            debug_assert!(!a.contains(((1, 0), (3, 3))));
+            debug_assert!(!a.contains(((1, 1), (3, 3))));
+            debug_assert!(!a.contains(((1, 1), (3, 3))));
         }
 
         #[test]
@@ -348,251 +174,67 @@ mod area_tests {
         // 2 +--+--+--+--+
 
         fn test_area() -> Area<i8> {
-            AreaBuilder::default()
-                .anchor((-1, -1))
-                .dimensions((2, 2))
-                .build()
-                .unwrap()
+            ((-1, -1), (2, 2)).into()
         }
 
         #[test]
         fn contains_one() {
             let a = test_area();
 
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((-1, -1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((0, -1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((-1, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.contains(((-1, -1), (1, 1))));
+            debug_assert!(a.contains(((0, -1), (1, 1))));
+            debug_assert!(a.contains(((0, 0), (1, 1))));
+            debug_assert!(a.contains(((-1, 0), (1, 1))));
         }
 
         #[test]
         fn contains_self() {
             let a = test_area();
 
-            debug_assert!(a.contains(
-                AreaBuilder::default()
-                    .anchor((-1, -1))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.contains(((-1, -1), (2, 2))));
         }
 
         #[test]
         fn no_neighboring_1x1s() {
             let a = test_area();
 
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-2, -2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-2, -1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-2, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-2, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-2, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-1, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, -1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, -2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((1, -2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, -2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-1, -2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(!a.contains(((-2, -2), (1, 1))));
+            debug_assert!(!a.contains(((-2, -1), (1, 1))));
+            debug_assert!(!a.contains(((-2, 0), (1, 1))));
+            debug_assert!(!a.contains(((-2, 1), (1, 1))));
+            debug_assert!(!a.contains(((-2, 2), (1, 1))));
+            debug_assert!(!a.contains(((-1, 2), (1, 1))));
+            debug_assert!(!a.contains(((0, 2), (1, 1))));
+            debug_assert!(!a.contains(((1, 2), (1, 1))));
+            debug_assert!(!a.contains(((2, 2), (1, 1))));
+            debug_assert!(!a.contains(((2, 1), (1, 1))));
+            debug_assert!(!a.contains(((2, 0), (1, 1))));
+            debug_assert!(!a.contains(((2, -1), (1, 1))));
+            debug_assert!(!a.contains(((2, -2), (1, 1))));
+            debug_assert!(!a.contains(((1, -2), (1, 1))));
+            debug_assert!(!a.contains(((0, -2), (1, 1))));
+            debug_assert!(!a.contains(((-1, -2), (1, 1))));
         }
 
         #[test]
         fn no_overlapping_2x2s() {
             let a = test_area();
 
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-2, -2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(!a.contains(((0, 0), (2, 2))));
+            debug_assert!(!a.contains(((2, 2), (2, 2))));
+            debug_assert!(!a.contains(((-2, -2), (2, 2))));
         }
 
         #[test]
         fn no_overlapping_3x3s() {
             let a = test_area();
 
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((1, 0))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-1, -1))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-1, 1))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-2, 1))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.contains(
-                AreaBuilder::default()
-                    .anchor((-2, -2))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(!a.contains(((0, 0), (3, 3))));
+            debug_assert!(!a.contains(((1, 0), (3, 3))));
+            debug_assert!(!a.contains(((-1, -1), (3, 3))));
+            debug_assert!(!a.contains(((-1, 1), (3, 3))));
+            debug_assert!(!a.contains(((-2, 1), (3, 3))));
+            debug_assert!(!a.contains(((-2, -2), (3, 3))));
         }
 
         #[test]
@@ -645,11 +287,7 @@ mod area_tests {
         // 6 +--+--+--+--+--+--+
 
         fn test_area() -> Area<u8> {
-            AreaBuilder::default()
-                .anchor((2, 2))
-                .dimensions((2, 2))
-                .build()
-                .unwrap()
+            ((2, 2), (2, 2)).into()
         }
 
         // All the 1x1s obviously contains.
@@ -657,34 +295,10 @@ mod area_tests {
         fn area_1x1() {
             let a = test_area();
 
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((2, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((3, 2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.intersects(((2, 2), (1, 1))));
+            debug_assert!(a.intersects(((2, 3), (1, 1))));
+            debug_assert!(a.intersects(((3, 2), (1, 1))));
+            debug_assert!(a.intersects(((3, 3), (1, 1))));
         }
 
         // And the one 2x2 obviously contained.
@@ -692,13 +306,7 @@ mod area_tests {
         fn area_2x2() {
             let a = test_area();
 
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.intersects(((2, 2), (2, 2))));
         }
 
         // But a single edge shared is not enough.
@@ -706,97 +314,19 @@ mod area_tests {
         fn area_with_only_a_single_shared_edge() {
             let a = test_area();
 
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((2, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((4, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((2, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((3, 1))
-                    .dimensions((2, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((4, 1))
-                    .dimensions((2, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((1, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 2))
-                    .dimensions((1, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 3))
-                    .dimensions((1, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 4))
-                    .dimensions((1, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((2, 4))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((3, 4))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((4, 4))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(!a.intersects(((1, 1), (1, 1))));
+            debug_assert!(!a.intersects(((1, 1), (2, 1))));
+            debug_assert!(!a.intersects(((1, 1), (4, 1))));
+            debug_assert!(!a.intersects(((2, 1), (1, 1))));
+            debug_assert!(!a.intersects(((3, 1), (2, 1))));
+            debug_assert!(!a.intersects(((4, 1), (2, 1))));
+            debug_assert!(!a.intersects(((1, 1), (1, 2))));
+            debug_assert!(!a.intersects(((1, 2), (1, 2))));
+            debug_assert!(!a.intersects(((1, 3), (1, 2))));
+            debug_assert!(!a.intersects(((1, 4), (1, 2))));
+            debug_assert!(!a.intersects(((2, 4), (1, 1))));
+            debug_assert!(!a.intersects(((3, 4), (1, 1))));
+            debug_assert!(!a.intersects(((4, 4), (1, 1))));
         }
 
         // But intersecting a 1x1 region counts.
@@ -804,48 +334,16 @@ mod area_tests {
         fn area_with_a_1x1_overlap() {
             let a = test_area();
 
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 3))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.intersects(((1, 1), (2, 2))));
+            debug_assert!(a.intersects(((0, 0), (3, 3))));
+            debug_assert!(a.intersects(((3, 3), (2, 2))));
+            debug_assert!(a.intersects(((1, 3), (2, 2))));
         }
 
         #[test]
         fn regression_test() {
-            let a: Area<u8> = AreaBuilder::default()
-                .anchor((3, 3))
-                .dimensions((2, 2))
-                .build()
-                .unwrap();
-            let b: Area<u8> = AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((6, 6))
-                .build()
-                .unwrap();
+            let a: Area<u8> = ((3, 3), (2, 2)).into();
+            let b: Area<u8> = ((0, 0), (6, 6)).into();
 
             debug_assert!(b.intersects(a));
             debug_assert!(a.intersects(b));
@@ -872,129 +370,41 @@ mod area_tests {
         // 3 +--+--+--+--+--+--+
 
         fn test_area() -> Area<i8> {
-            AreaBuilder::default()
-                .anchor((-1, -1))
-                .dimensions((2, 2))
-                .build()
-                .unwrap()
+            ((-1, -1), (2, 2)).into()
         }
 
         #[test]
         fn area_1x1() {
             let a = test_area();
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((-1, -1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((-1, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((0, -1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.intersects(((-1, -1), (1, 1))));
+            debug_assert!(a.intersects(((-1, 0), (1, 1))));
+            debug_assert!(a.intersects(((0, 0), (1, 1))));
+            debug_assert!(a.intersects(((0, -1), (1, 1))));
         }
 
         #[test]
         fn area_self() {
             let a = test_area();
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((-1, -1))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.intersects(((-1, -1), (2, 2))));
         }
 
         #[test]
         fn area_with_a_1x1_overlap() {
             let a = test_area();
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((-2, -2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((0, -2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(a.intersects(
-                AreaBuilder::default()
-                    .anchor((-2, 0))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(a.intersects(((-2, -2), (2, 2))));
+            debug_assert!(a.intersects(((0, -2), (2, 2))));
+            debug_assert!(a.intersects(((0, 0), (2, 2))));
+            debug_assert!(a.intersects(((-2, 0), (2, 2))));
         }
 
         #[test]
         fn area_with_only_a_single_shared_edge() {
             let a = test_area();
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, -1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((-1, 1))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((-2, 0))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
-            debug_assert!(!a.intersects(
-                AreaBuilder::default()
-                    .anchor((-2, -2))
-                    .dimensions((1, 1))
-                    .build()
-                    .unwrap()
-            ));
+            debug_assert!(!a.intersects(((1, -1), (1, 1))));
+            debug_assert!(!a.intersects(((1, 1), (1, 1))));
+            debug_assert!(!a.intersects(((-1, 1), (1, 1))));
+            debug_assert!(!a.intersects(((-2, 0), (1, 1))));
+            debug_assert!(!a.intersects(((-2, -2), (1, 1))));
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,7 +14,7 @@
 
 mod util; // For unordered_elements_are.
 
-use quadtree_rs::{area::AreaBuilder, Quadtree};
+use quadtree_rs::Quadtree;
 
 mod new {
     use super::*;
@@ -72,62 +72,27 @@ mod insert {
     #[test]
     fn insert_successful() {
         let mut qt = Quadtree::<u32, u8>::new(2);
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((2, 3))
-                    .build()
-                    .unwrap(),
-                4,
-            )
-            .is_some());
-        assert!(qt
-            .insert(AreaBuilder::default().anchor((1, 1)).build().unwrap(), 3,)
-            .is_some());
+        assert!(qt.insert(((0, 0), (2, 3)), 4,).is_some());
+        assert!(qt.insert((1, 1), 3).is_some());
 
         // The full bounds of the region.
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((4, 4))
-                    .build()
-                    .unwrap(),
-                17,
-            )
-            .is_some());
+        assert!(qt.insert(((0, 0), (4, 4)), 17,).is_some());
         // At (3, 3) but 1x1
-        assert!(qt
-            .insert(AreaBuilder::default().anchor((3, 3)).build().unwrap(), 19,)
-            .is_some());
+        assert!(qt.insert((3, 3), 19).is_some());
     }
 
     #[test]
     fn insert_unsucessful() {
         let mut qt = Quadtree::<u32, u8>::new(2);
         // At (0, 0) and too large.
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((5, 5))
-                    .build()
-                    .unwrap(),
-                17,
-            )
-            .is_none());
+        assert!(qt.insert(((0, 0), (5, 5)), 17,).is_none());
 
         // At (4, 4) but 1x1.
-        assert!(qt
-            .insert(AreaBuilder::default().anchor((4, 4)).build().unwrap(), 20,)
-            .is_none());
+        assert!(qt.insert((4, 4), 20).is_none());
 
         // Since the region overlaps, insertion fails.
         let mut qt = Quadtree::<u32, u16>::new_with_anchor((2, 2).into(), 2);
-        assert!(qt
-            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 25,)
-            .is_none());
+        assert!(qt.insert((0, 0), 25).is_none());
     }
 }
 
@@ -135,19 +100,13 @@ mod insert {
 fn len() {
     let mut qt = Quadtree::<u32, u32>::new(4);
     debug_assert_eq!(qt.len(), 0);
-    assert!(qt
-        .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 2,)
-        .is_some());
+    assert!(qt.insert((0, 0), 2).is_some());
     debug_assert_eq!(qt.len(), 1);
     // Even if it's the same thing again.
-    assert!(qt
-        .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 2,)
-        .is_some());
+    assert!(qt.insert((0, 0), 2).is_some());
     debug_assert_eq!(qt.len(), 2);
     // Or if it's a point.
-    assert!(qt
-        .insert(AreaBuilder::default().anchor((2, 3)).build().unwrap(), 2,)
-        .is_some());
+    assert!(qt.insert((2, 3), 2).is_some());
     debug_assert_eq!(qt.len(), 3);
 }
 
@@ -156,30 +115,12 @@ fn fill_quadrant() {
     let mut qt = Quadtree::<u8, f64>::new(2);
     debug_assert!(qt.is_empty());
 
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            49.17,
-        )
-        .is_some());
+    assert!(qt.insert(((0, 0), (2, 2)), 49.17,).is_some());
     // This should 100% fill one quadrant.
     debug_assert_eq!(qt.len(), 1);
     debug_assert!(!qt.is_empty());
 
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((2, 2))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            71.94,
-        )
-        .is_some()); // This should 100% fill one quadrant.
+    assert!(qt.insert(((2, 2), (2, 2)), 71.94,).is_some()); // This should 100% fill one quadrant.
     debug_assert_eq!(qt.len(), 2);
     debug_assert!(!qt.is_empty());
 }
@@ -190,25 +131,14 @@ fn is_empty() {
     debug_assert!(qt.is_empty());
 
     // Insert region
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            49,
-        )
-        .is_some());
+    assert!(qt.insert(((0, 0), (2, 2)), 49,).is_some());
     debug_assert!(!qt.is_empty());
 
     let mut q2 = Quadtree::<u32, u32>::new(4);
     debug_assert!(q2.is_empty());
 
     // Insert point
-    assert!(q2
-        .insert(AreaBuilder::default().anchor((1, 1)).build().unwrap(), 50,)
-        .is_some());
+    assert!(q2.insert((1, 1), 50).is_some());
     debug_assert!(!q2.is_empty());
 }
 
@@ -217,12 +147,7 @@ fn reset() {
     let mut qt = Quadtree::<u32, f32>::new(4);
     debug_assert!(qt.is_empty());
 
-    assert!(qt
-        .insert(
-            AreaBuilder::default().anchor((2, 2)).build().unwrap(),
-            57.27,
-        )
-        .is_some());
+    assert!(qt.insert((2, 2), 57.27,).is_some());
     debug_assert!(!qt.is_empty());
 
     qt.reset();
@@ -237,38 +162,19 @@ mod string {
     #[test]
     fn quadtree_string() {
         let mut qt = Quadtree::<u32, String>::new(4);
-        assert!(qt
-            .insert(
-                AreaBuilder::default().anchor((0, 0)).build().unwrap(),
-                "foo_bar_baz".to_string(),
-            )
-            .is_some());
+        assert!(qt.insert((0, 0), "foo_bar_baz".to_string(),).is_some());
 
-        let mut iter = qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap());
+        let mut iter = qt.query((0, 0));
         assert_eq!(iter.next().unwrap().value_ref(), "foo_bar_baz");
     }
 
     #[test]
     fn quadtree_mut_string() {
         let mut qt = Quadtree::<u32, String>::new(4);
-        assert!(qt
-            .insert(
-                AreaBuilder::default().anchor((0, 0)).build().unwrap(),
-                "hello ".to_string(),
-            )
-            .is_some());
-        qt.modify(
-            AreaBuilder::default().anchor((0, 0)).build().unwrap(),
-            |v| *v += "world",
-        );
+        assert!(qt.insert((0, 0), "hello ".to_string(),).is_some());
+        qt.modify((0, 0), |v| *v += "world");
 
-        assert_eq!(
-            qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
-                .next()
-                .unwrap()
-                .value_ref(),
-            "hello world"
-        );
+        assert_eq!(qt.query((0, 0)).next().unwrap().value_ref(), "hello world");
     }
 }
 
@@ -287,18 +193,9 @@ fn quadtree_struct() {
 
     let mut qt = Quadtree::<u32, Foo>::new(4);
 
-    assert!(qt
-        .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), foo,)
-        .is_some());
+    assert!(qt.insert((0, 0), foo,).is_some());
 
-    assert_eq!(
-        qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
-            .next()
-            .unwrap()
-            .value_ref()
-            .baz,
-        "baz"
-    );
+    assert_eq!(qt.query((0, 0)).next().unwrap().value_ref().baz, "baz");
 }
 
 // Since we implement Extend<((U, U), V)> for Quadtree<U, V>, test out .extend()ing with a real
@@ -315,10 +212,7 @@ mod extend {
 
         debug_assert_eq!(qt.len(), 2);
 
-        let entry_zero = qt
-            .query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
-            .next()
-            .unwrap();
+        let entry_zero = qt.query((0, 0)).next().unwrap();
         let area_zero = entry_zero.area();
         debug_assert_eq!(area_zero.anchor(), (0, 0).into());
         debug_assert_eq!(area_zero.width(), 1);
@@ -326,10 +220,7 @@ mod extend {
 
         debug_assert_eq!(entry_zero.value_ref(), &0);
 
-        let entry_five = qt
-            .query(AreaBuilder::default().anchor((2, 3)).build().unwrap())
-            .next()
-            .unwrap();
+        let entry_five = qt.query((2, 3)).next().unwrap();
         let area_five = entry_five.area();
         debug_assert_eq!(area_five.anchor(), (2, 3).into());
         debug_assert_eq!(area_five.width(), 1);
@@ -343,36 +234,13 @@ mod extend {
         let mut qt = Quadtree::<u32, i8>::new(3);
         assert!(qt.is_empty());
 
-        assert!(qt
-            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 0,)
-            .is_some());
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((2, 3))
-                    .dimensions((3, 4))
-                    .build()
-                    .unwrap(),
-                5,
-            )
-            .is_some());
+        assert!(qt.insert((0, 0), 0).is_some());
+        assert!(qt.insert(((2, 3), (3, 4)), 5,).is_some());
 
         debug_assert_eq!(qt.len(), 2);
 
-        debug_assert_eq!(
-            qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
-                .next()
-                .unwrap()
-                .value_ref(),
-            &0
-        );
-        debug_assert_eq!(
-            qt.query(AreaBuilder::default().anchor((2, 3)).build().unwrap())
-                .next()
-                .unwrap()
-                .value_ref(),
-            &5
-        );
+        debug_assert_eq!(qt.query((0, 0)).next().unwrap().value_ref(), &0);
+        debug_assert_eq!(qt.query((2, 3)).next().unwrap().value_ref(), &5);
     }
 }
 
@@ -387,9 +255,7 @@ mod delete {
         debug_assert_eq!(qt.len(), 4);
 
         // But we will be sure to retain this one.
-        let handle = qt
-            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 11)
-            .unwrap();
+        let handle = qt.insert((0, 0), 11).unwrap();
         debug_assert_eq!(qt.len(), 5); // Insertion succeeded.
 
         // Check the returned entry.
@@ -405,11 +271,7 @@ mod delete {
         debug_assert_eq!(qt.len(), 4); // Insertion succeeded.
 
         // And, check that queries over the previous area don't crash or return garbage indices.
-        debug_assert_eq!(
-            qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap())
-                .count(),
-            1
-        );
+        debug_assert_eq!(qt.query((0, 0)).count(), 1);
     }
 }
 
@@ -417,39 +279,10 @@ mod delete {
 #[ignore]
 fn debug() {
     let mut qt = Quadtree::<u8, f64>::new(2);
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            1.35,
-        )
-        .is_some());
-    assert!(qt
-        .insert(AreaBuilder::default().anchor((1, 1)).build().unwrap(), 2.46,)
-        .is_some());
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((1, 1))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            3.69,
-        )
-        .is_some());
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((2, 2))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            4.812,
-        )
-        .is_some());
+    assert!(qt.insert(((0, 0), (2, 2)), 1.35,).is_some());
+    assert!(qt.insert((1, 1), 2.46).is_some());
+    assert!(qt.insert(((1, 1), (2, 2)), 3.69,).is_some());
+    assert!(qt.insert(((2, 2), (2, 2)), 4.812,).is_some());
     dbg!(&qt);
 }
 
@@ -459,48 +292,10 @@ fn test_print_quadtree() {
     use crate::util::print_quadtree;
 
     let mut qt = Quadtree::<u8, f64>::new(3);
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            1.35,
-        )
-        .is_some());
-    assert!(qt
-        .insert(AreaBuilder::default().anchor((2, 3)).build().unwrap(), 2.46,)
-        .is_some());
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((1, 1))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            3.69,
-        )
-        .is_some());
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((2, 2))
-                .dimensions((4, 4))
-                .build()
-                .unwrap(),
-            4.812,
-        )
-        .is_some());
-    assert!(qt
-        .insert(
-            AreaBuilder::default()
-                .anchor((0, 4))
-                .dimensions((2, 3))
-                .build()
-                .unwrap(),
-            4.812,
-        )
-        .is_some());
+    assert!(qt.insert(((0, 0), (2, 2)), 1.35,).is_some());
+    assert!(qt.insert((2, 3), 2.46,).is_some());
+    assert!(qt.insert(((1, 1), (2, 2)), 3.69,).is_some());
+    assert!(qt.insert(((2, 2), (4, 4)), 4.812,).is_some());
+    assert!(qt.insert(((0, 4), (2, 3)), 4.812,).is_some());
     print_quadtree(&qt);
 }

--- a/tests/iterator_tests.rs
+++ b/tests/iterator_tests.rs
@@ -18,7 +18,7 @@ mod util; // For unordered_elements_are.
 mod iterator_tests {
     use {
         crate::util::unordered_elements_are,
-        quadtree_rs::{area::AreaBuilder, entry::Entry, Quadtree},
+        quadtree_rs::{entry::Entry, Quadtree},
     };
 
     fn mk_quadtree_for_iter_tests() -> Quadtree<i32, i8> {
@@ -83,13 +83,7 @@ mod iterator_tests {
     fn delete_everything() {
         let mut qt = mk_quadtree_for_iter_tests();
         debug_assert_eq!(qt.len(), 3);
-        qt.delete(
-            AreaBuilder::default()
-                .anchor((-35, -35))
-                .dimensions((80, 80))
-                .build()
-                .unwrap(),
-        );
+        qt.delete(((-35, -35), (80, 80)));
         debug_assert_eq!(qt.len(), 0);
     }
 
@@ -98,19 +92,15 @@ mod iterator_tests {
         let mut qt = mk_quadtree_for_iter_tests();
         debug_assert_eq!(qt.len(), 3);
         // Near miss.
-        qt.delete(AreaBuilder::default().anchor((29, -36)).build().unwrap());
+        qt.delete((29, -36));
         debug_assert_eq!(qt.len(), 3);
 
         // Direct hit!
-        let mut returned_entries =
-            qt.delete(AreaBuilder::default().anchor((30, -35)).build().unwrap());
+        let mut returned_entries = qt.delete((30, -35));
         debug_assert_eq!(qt.len(), 2);
         let hit = returned_entries.next().unwrap();
         debug_assert_eq!(hit.value_ref(), &40);
-        debug_assert_eq!(
-            hit.area(),
-            AreaBuilder::default().anchor((30, -35)).build().unwrap()
-        );
+        debug_assert_eq!(hit.area(), (30, -35).into());
     }
 
     #[test]
@@ -119,15 +109,7 @@ mod iterator_tests {
         debug_assert_eq!(qt.len(), 3);
 
         // Just large enough to encompass the two points.
-        let returned_entries: Vec<Entry<i32, i8>> = qt
-            .delete(
-                AreaBuilder::default()
-                    .anchor((-15, -5))
-                    .dimensions((16, 26))
-                    .build()
-                    .unwrap(),
-            )
-            .collect();
+        let returned_entries: Vec<Entry<i32, i8>> = qt.delete(((-15, -5), (16, 26))).collect();
         debug_assert_eq!(qt.len(), 1);
 
         debug_assert!(unordered_elements_are(

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -16,33 +16,22 @@ mod util; // For unordered_elements_are.
 
 // For testing .query(), .modify().
 mod query_tests {
-    use {
-        crate::util::unordered_elements_are,
-        quadtree_rs::{area::AreaBuilder, Quadtree},
-    };
+    use {crate::util::unordered_elements_are, quadtree_rs::Quadtree};
 
     #[test]
     fn query_empty() {
         let qt = Quadtree::<u32, u8>::new(2);
-        let mut iter = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((4, 4))
-                .build()
-                .unwrap(),
-        );
+        let mut iter = qt.query(((0, 0), (4, 4)));
         debug_assert_eq!(iter.next(), None);
     }
 
     #[test]
     fn query_on_point() {
         let mut qt = Quadtree::<u32, u8>::new(1);
-        assert!(qt
-            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 49,)
-            .is_some());
+        assert!(qt.insert((0, 0), 49,).is_some());
 
         // Requesting a region which does contain '49'.
-        let mut iter1 = qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap());
+        let mut iter1 = qt.query((0, 0));
         let entry = iter1.next().unwrap();
         let entry_area = entry.area();
 
@@ -55,13 +44,13 @@ mod query_tests {
         debug_assert_eq!(iter1.next(), None);
 
         // Requesting regions which don't contain '49'.
-        let mut iter2 = qt.query(AreaBuilder::default().anchor((0, 1)).build().unwrap());
+        let mut iter2 = qt.query((0, 1));
         debug_assert_eq!(iter2.next(), None);
 
-        let mut iter3 = qt.query(AreaBuilder::default().anchor((1, 0)).build().unwrap());
+        let mut iter3 = qt.query((1, 0));
         debug_assert_eq!(iter3.next(), None);
 
-        let mut iter4 = qt.query(AreaBuilder::default().anchor((1, 1)).build().unwrap());
+        let mut iter4 = qt.query((1, 1));
         debug_assert_eq!(iter4.next(), None);
     }
 
@@ -82,168 +71,91 @@ mod query_tests {
         // 5 +--+--+--x x x x--+
         //   |  |  |  |  |  |  |
         // 6 +--+--+--+--+--+--+
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap(),
-                10,
-            )
-            .is_some());
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap(),
-                55,
-            )
-            .is_some());
+        assert!(qt.insert(((2, 2), (2, 2)), 10,).is_some());
+        assert!(qt.insert(((3, 3), (2, 2)), 55,).is_some());
 
         // Queries which turn up empty:
-        let mut empty1 = qt.query(AreaBuilder::default().anchor((1, 1)).build().unwrap());
+        let mut empty1 = qt.query((1, 1));
         debug_assert_eq!(empty1.next(), None);
 
-        let mut empty2 = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-        );
+        let mut empty2 = qt.query(((0, 0), (2, 2)));
         debug_assert_eq!(empty2.next(), None);
 
-        let mut empty3 = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((6, 2))
-                .build()
-                .unwrap(),
-        );
+        let mut empty3 = qt.query(((0, 0), (6, 2)));
         debug_assert_eq!(empty3.next(), None);
 
-        let mut empty4 = qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((2, 6))
-                .build()
-                .unwrap(),
-        );
+        let mut empty4 = qt.query(((0, 0), (2, 6)));
         debug_assert_eq!(empty4.next(), None);
 
         // Queries which capture #10:
-        let mut ten1 = qt.query(AreaBuilder::default().anchor((2, 2)).build().unwrap());
+        let mut ten1 = qt.query((2, 2));
         debug_assert_eq!(ten1.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten1.next(), None);
 
-        let mut ten2 = qt.query(AreaBuilder::default().anchor((2, 3)).build().unwrap());
+        let mut ten2 = qt.query((2, 3));
         debug_assert_eq!(ten2.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten2.next(), None);
 
-        let mut ten3 = qt.query(AreaBuilder::default().anchor((3, 2)).build().unwrap());
+        let mut ten3 = qt.query((3, 2));
         debug_assert_eq!(ten3.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten3.next(), None);
 
         // Queries which capture #10 but are larger than 1x1.
-        let mut ten4 = qt.query(
-            AreaBuilder::default()
-                .anchor((2, 2))
-                .dimensions((2, 1))
-                .build()
-                .unwrap(),
-        );
+        let mut ten4 = qt.query(((2, 2), (2, 1)));
         debug_assert_eq!(ten4.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten4.next(), None);
 
-        let mut ten5 = qt.query(AreaBuilder::default().anchor((2, 2)).build().unwrap());
+        let mut ten5 = qt.query((2, 2));
         debug_assert_eq!(ten5.next().unwrap().value_ref(), &10);
         debug_assert_eq!(ten5.next(), None);
 
         // Queries which capture #55:
-        let mut fiftyfive1 = qt.query(AreaBuilder::default().anchor((3, 4)).build().unwrap());
+        let mut fiftyfive1 = qt.query((3, 4));
         debug_assert_eq!(fiftyfive1.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive1.next(), None);
 
-        let mut fiftyfive2 = qt.query(AreaBuilder::default().anchor((4, 3)).build().unwrap());
+        let mut fiftyfive2 = qt.query((4, 3));
         debug_assert_eq!(fiftyfive2.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive2.next(), None);
 
-        let mut fiftyfive3 = qt.query(AreaBuilder::default().anchor((4, 4)).build().unwrap());
+        let mut fiftyfive3 = qt.query((4, 4));
         debug_assert_eq!(fiftyfive3.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive3.next(), None);
 
         // Queries which capture #55 but are larger than 1x1.
 
-        let mut fiftyfive4 = qt.query(AreaBuilder::default().anchor((4, 3)).build().unwrap());
+        let mut fiftyfive4 = qt.query((4, 3));
         debug_assert_eq!(fiftyfive4.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive4.next(), None);
 
-        let mut fiftyfive5 = qt.query(
-            AreaBuilder::default()
-                .anchor((3, 4))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-        );
+        let mut fiftyfive5 = qt.query(((3, 4), (2, 2)));
         debug_assert_eq!(fiftyfive5.next().unwrap().value_ref(), &55);
         debug_assert_eq!(fiftyfive5.next(), None);
 
         // Queries which capture both #10 and #55. Dunno in what order.
 
         debug_assert!(unordered_elements_are(
-            qt.query(AreaBuilder::default().anchor((3, 3)).build().unwrap())
-                .map(|e| e.value_ref()),
+            qt.query((3, 3)).map(|e| e.value_ref()),
             vec![&10, &55],
         ));
 
         debug_assert!(unordered_elements_are(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            )
-            .map(|e| e.value_ref()),
+            qt.query(((3, 3), (3, 3))).map(|e| e.value_ref()),
             vec![&10, &55],
         ));
 
         debug_assert!(unordered_elements_are(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((6, 6))
-                    .build()
-                    .unwrap()
-            )
-            .map(|e| e.value_ref()),
+            qt.query(((0, 0), (6, 6))).map(|e| e.value_ref()),
             vec![&10, &55],
         ));
 
         debug_assert!(unordered_elements_are(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((6, 6))
-                    .build()
-                    .unwrap()
-            )
-            .map(|e| e.value_ref()),
+            qt.query(((2, 2), (6, 6))).map(|e| e.value_ref()),
             vec![&10, &55],
         ));
 
         debug_assert!(unordered_elements_are(
-            qt.query(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            )
-            .map(|e| e.value_ref()),
+            qt.query(((2, 2), (2, 2))).map(|e| e.value_ref()),
             vec![&10, &55],
         ));
     }
@@ -265,242 +177,84 @@ mod query_tests {
         // 5 +--+--+--x x x x--+
         //   |  |  |  |  |  |  |
         // 6 +--+--+--+--+--+--+
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap(),
-                10,
-            )
-            .is_some());
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap(),
-                55,
-            )
-            .is_some());
+        assert!(qt.insert(((2, 2), (2, 2)), 10,).is_some());
+        assert!(qt.insert(((3, 3), (2, 2)), 55,).is_some());
 
         // Queries which turn up empty:
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((1, 1)).build().unwrap())
-                .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((6, 2))
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((2, 6))
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
+        debug_assert_eq!(qt.query_strict((1, 1)).next(), None);
+        debug_assert_eq!(qt.query_strict(((0, 0), (2, 2))).next(), None);
+        debug_assert_eq!(qt.query_strict(((0, 0), (6, 2))).next(), None);
+        debug_assert_eq!(qt.query_strict(((0, 0), (2, 6))).next(), None);
 
         // Queries which capture portions of #10 but not enough.
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((2, 2)).build().unwrap())
-                .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((2, 3)).build().unwrap())
-                .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((3, 2)).build().unwrap())
-                .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((2, 1))
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((2, 2)).build().unwrap())
-                .next(),
-            None
-        );
+        debug_assert_eq!(qt.query_strict((2, 2)).next(), None);
+        debug_assert_eq!(qt.query_strict((2, 3)).next(), None);
+        debug_assert_eq!(qt.query_strict((3, 2)).next(), None);
+        debug_assert_eq!(qt.query_strict(((2, 2), (2, 1))).next(), None);
+        debug_assert_eq!(qt.query_strict((2, 2)).next(), None);
 
         // Queries which capture portions of #55 but not enough.
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((3, 4)).build().unwrap())
-                .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((4, 3)).build().unwrap())
-                .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((4, 4)).build().unwrap())
-                .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((4, 3)).build().unwrap())
-                .next(),
-            None
-        );
-        debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((3, 4))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            )
-            .next(),
-            None
-        );
+        debug_assert_eq!(qt.query_strict((3, 4)).next(), None);
+        debug_assert_eq!(qt.query_strict((4, 3)).next(), None);
+        debug_assert_eq!(qt.query_strict((4, 4)).next(), None);
+        debug_assert_eq!(qt.query_strict((4, 3)).next(), None);
+        debug_assert_eq!(qt.query_strict(((3, 4), (2, 2))).next(), None);
 
         // Queries which capture portions of both #10 and #55. but still aren't enough
 
-        debug_assert_eq!(
-            qt.query_strict(AreaBuilder::default().anchor((3, 3)).build().unwrap())
-                .next(),
-            None
-        );
+        debug_assert_eq!(qt.query_strict((3, 3)).next(), None);
 
         // Queries which contain one of the other:
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query_strict(((3, 3), (2, 2)))
+                .next()
+                .unwrap()
+                .value_ref(),
             &55
         );
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query_strict(((3, 3), (3, 3)))
+                .next()
+                .unwrap()
+                .value_ref(),
             &55
         );
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((3, 3))
-                    .dimensions((4, 4))
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query_strict(((3, 3), (4, 4)))
+                .next()
+                .unwrap()
+                .value_ref(),
             &55
         );
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((4, 4))
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query_strict(((0, 0), (4, 4)))
+                .next()
+                .unwrap()
+                .value_ref(),
             &10
         );
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((1, 1))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query_strict(((1, 1), (3, 3)))
+                .next()
+                .unwrap()
+                .value_ref(),
             &10
         );
         debug_assert_eq!(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap()
-            )
-            .next()
-            .unwrap()
-            .value_ref(),
+            qt.query_strict(((2, 2), (2, 2)))
+                .next()
+                .unwrap()
+                .value_ref(),
             &10
         );
 
         // A query which contains both:
         debug_assert!(unordered_elements_are(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((6, 6))
-                    .build()
-                    .unwrap()
-            )
-            .map(|e| e.value_ref()),
+            qt.query_strict(((0, 0), (6, 6))).map(|e| e.value_ref()),
             vec![&10, &55]
         ));
         debug_assert!(unordered_elements_are(
-            qt.query_strict(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((6, 6))
-                    .build()
-                    .unwrap()
-            )
-            .map(|e| e.value_ref()),
+            qt.query_strict(((2, 2), (6, 6))).map(|e| e.value_ref()),
             vec![&10, &55]
         ));
     }
@@ -508,18 +262,9 @@ mod query_tests {
     #[test]
     fn query_exhibiting_collection() {
         let mut qt: Quadtree<u8, f32> = Quadtree::new(2);
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((0, 0))
-                    .dimensions((2, 2))
-                    .build()
-                    .unwrap(),
-                1.234,
-            )
-            .is_some());
+        assert!(qt.insert(((0, 0), (2, 2)), 1.234,).is_some());
 
-        let mut query_obj = qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap());
+        let mut query_obj = qt.query((0, 0));
 
         debug_assert_eq!(query_obj.next().unwrap().value_ref(), &1.234);
     }
@@ -528,14 +273,7 @@ mod query_tests {
     fn modify_empty() {
         // Modification shouldn't change the emptiness.
         let mut qt = Quadtree::<u32, u8>::new(2);
-        qt.modify(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((4, 4))
-                .build()
-                .unwrap(),
-            |v| *v *= 2,
-        );
+        qt.modify(((0, 0), (4, 4)), |v| *v *= 2);
         debug_assert!(qt.is_empty());
     }
 
@@ -544,63 +282,29 @@ mod query_tests {
         let mut qt = Quadtree::<u32, u8>::new(3);
 
         // Insert #49 at (0, 0)->1x1.
-        assert!(qt
-            .insert(AreaBuilder::default().anchor((0, 0)).build().unwrap(), 49,)
-            .is_some());
-        qt.modify(
-            AreaBuilder::default().anchor((0, 0)).build().unwrap(),
-            |i| *i += 1,
-        );
+        assert!(qt.insert((0, 0), 49,).is_some());
+        qt.modify((0, 0), |i| *i += 1);
 
         // And verify.
-        let mut tmp_iter_1 = qt.query(AreaBuilder::default().anchor((0, 0)).build().unwrap());
+        let mut tmp_iter_1 = qt.query((0, 0));
         debug_assert_eq!(tmp_iter_1.next().unwrap().value_ref(), &50);
         debug_assert_eq!(tmp_iter_1.next(), None);
 
         // Insert #17 at (2, 2)->3x3.
-        assert!(qt
-            .insert(
-                AreaBuilder::default()
-                    .anchor((2, 2))
-                    .dimensions((3, 3))
-                    .build()
-                    .unwrap(),
-                17,
-            )
-            .is_some());
+        assert!(qt.insert(((2, 2), (3, 3)), 17,).is_some());
 
         // Up it to 18,
-        qt.modify(
-            AreaBuilder::default()
-                .anchor((1, 1))
-                .dimensions((2, 2))
-                .build()
-                .unwrap(),
-            |i| *i += 1,
-        );
+        qt.modify(((1, 1), (2, 2)), |i| *i += 1);
         // And verify.
-        let mut tmp_iter_2 = qt.query(AreaBuilder::default().anchor((2, 2)).build().unwrap());
+        let mut tmp_iter_2 = qt.query((2, 2));
         debug_assert_eq!(tmp_iter_2.next().unwrap().value_ref(), &18);
         debug_assert_eq!(tmp_iter_2.next(), None);
 
         // Reset everything in (0, 0)->6x6 to "0".
-        qt.modify(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((6, 6))
-                .build()
-                .unwrap(),
-            |i| *i = 0,
-        );
+        qt.modify(((0, 0), (6, 6)), |i| *i = 0);
         // Every value is now 0.
 
-        for entry in qt.query(
-            AreaBuilder::default()
-                .anchor((0, 0))
-                .dimensions((6, 6))
-                .build()
-                .unwrap(),
-        ) {
+        for entry in qt.query(((0, 0), (6, 6))) {
             debug_assert_eq!(entry.value_ref(), &0);
         }
     }


### PR DESCRIPTION
This lets us coerce tuples into Areas without the builder pattern. This is safe to use if you already know your dimensions are valid. It makes our examples and tests dramatically terser.