### PR TITLE
Formatting changes

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+imports_layout = "Vertical"
+imports_granularity = "Crate"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ badge](https://img.shields.io/crates/v/quadtree_rs.svg)](https://crates.io/crate
 badge](https://docs.rs/quadtree_rs/badge.svg)](https://docs.rs/quadtree_rs)
 [![license](https://img.shields.io/crates/l/quadtree_rs.svg)](https://github.com/ambuc/quadtree/blob/master/LICENSE)
 
-[Point/region Quadtree](https://en.wikipedia.org/wiki/Quadtree) with support for 
+[Point/region Quadtree](https://en.wikipedia.org/wiki/Quadtree) with support for
 overlapping regions.
 
 For documentation, see [docs.rs/quadtree_rs](https://docs.rs/quadtree_rs/).
@@ -16,7 +16,7 @@ For documentation, see [docs.rs/quadtree_rs](https://docs.rs/quadtree_rs/).
 ```rust
 use quadtree_rs::{area::AreaBuilder, point::Point, Quadtree};
 
-// Instantiate a new quadtree which associates String values with u64 
+// Instantiate a new quadtree which associates String values with u64
 // coordinates.
 let mut qt = Quadtree::<u64, String>::new(/*depth=*/4);
 
@@ -37,7 +37,7 @@ let region_b = AreaBuilder::default()
     .build().unwrap();
 let mut query = qt.query(region_b);
 
-// The query region (region_b) intersects the region "foo" is associated with 
+// The query region (region_b) intersects the region "foo" is associated with
 // (region_a), so the query iterator returns "foo" by reference.
 assert_eq!(query.next().unwrap().value_ref(), "foo");
 ```
@@ -60,7 +60,7 @@ This project is licensed under the Apache 2.0 license.
 
 # Disclaimer
 
-This is not an official Google product. 
+This is not an official Google product.
 
 # TODO
  - [ ] Pretty-print quadtree function which plots a density map

--- a/development/README.md
+++ b/development/README.md
@@ -4,6 +4,6 @@
 
 There is a pre-commit hook inside `/development/hooks/pre-commit`. Install it by
 copying it to `.git/hooks/pre-commit`. This will run a suite of commands
-(format, test, etc.) automatically before a commit. 
+(format, test, etc.) automatically before a commit.
 
 NB: git pre-commit hooks can be invoked manually with `bash .git/hooks/pre-commit`.

--- a/src/area.rs
+++ b/src/area.rs
@@ -14,12 +14,17 @@
 
 //! A rectangular region in the tree.
 
+use crate::point;
+use num::PrimInt;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use {
-    crate::point,
-    num::PrimInt,
-    std::{cmp::PartialOrd, default::Default, fmt::Debug},
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use std::{
+    cmp::PartialOrd,
+    default::Default,
+    fmt::Debug,
 };
 
 /// A rectangular region in 2d space.

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -15,13 +15,17 @@
 //! A view into a single entry in the Quadtree.
 // Influenced by https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html.
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use {
-    crate::{area::Area, point::Point},
-    num::PrimInt,
-    std::default::Default,
+use crate::{
+    area::Area,
+    point::Point,
 };
+use num::PrimInt;
+#[cfg(feature = "serde")]
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use std::default::Default;
 
 /// A region/value association in the [`Quadtree`].
 ///

--- a/src/handle_iter.rs
+++ b/src/handle_iter.rs
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use {
-    crate::{area::Area, qtinner::QTInner, traversal::Traversal},
-    num::PrimInt,
-    std::{collections::HashSet, default::Default, iter::FusedIterator},
+use crate::{
+    area::Area,
+    qtinner::QTInner,
+    traversal::Traversal,
+};
+use num::PrimInt;
+use std::{
+    collections::HashSet,
+    default::Default,
+    iter::FusedIterator,
 };
 
 #[derive(Clone, Debug)]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use {
-    crate::{
-        area::Area, entry::Entry, handle_iter::HandleIter, qtinner::QTInner, traversal::Traversal,
-        types::StoreType,
-    },
-    num::PrimInt,
-    std::iter::FusedIterator,
+use crate::{
+    area::Area,
+    entry::Entry,
+    handle_iter::HandleIter,
+    qtinner::QTInner,
+    traversal::Traversal,
+    types::StoreType,
 };
+use num::PrimInt;
+use std::iter::FusedIterator;
 
 /// An iterator over all regions and values of a [`Quadtree`].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,25 +115,38 @@ mod qtinner;
 mod traversal;
 mod types;
 
+use crate::{
+    area::{
+        Area,
+        AreaBuilder,
+    },
+    entry::Entry,
+    handle_iter::HandleIter,
+    iter::{
+        IntoIter,
+        Iter,
+        Query,
+        Regions,
+        Values,
+    },
+    point::Point,
+    qtinner::QTInner,
+    traversal::Traversal,
+    types::StoreType,
+};
+use num::PrimInt;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use {
-    crate::{
-        area::{Area, AreaBuilder},
-        entry::Entry,
-        handle_iter::HandleIter,
-        iter::{IntoIter, Iter, Query, Regions, Values},
-        point::Point,
-        qtinner::QTInner,
-        traversal::Traversal,
-        types::StoreType,
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use std::{
+    collections::{
+        HashMap,
+        HashSet,
     },
-    num::PrimInt,
-    std::{
-        collections::{HashMap, HashSet},
-        default::Default,
-        hash::Hash,
-    },
+    default::Default,
+    hash::Hash,
 };
 
 /// A data structure for storing and accessing data in 2d space.

--- a/src/point.rs
+++ b/src/point.rs
@@ -14,13 +14,17 @@
 
 //! A point region in the tree.
 
+use num::PrimInt;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use {
-    num::PrimInt,
-    std::{
-        fmt::Debug,
-        ops::{Add, Sub},
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use std::{
+    fmt::Debug,
+    ops::{
+        Add,
+        Sub,
     },
 };
 

--- a/src/qtinner.rs
+++ b/src/qtinner.rs
@@ -12,12 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::{
+    area::Area,
+    entry::Entry,
+    point::Point,
+    types::StoreType,
+};
+use num::PrimInt;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use {
-    crate::{area::Area, entry::Entry, point::Point, types::StoreType},
-    num::PrimInt,
-    std::{default::Default, fmt::Debug},
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use std::{
+    default::Default,
+    fmt::Debug,
 };
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use {crate::area::Area, num::PrimInt, std::default::Default};
+use crate::area::Area;
+use num::PrimInt;
+use std::default::Default;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Traversal {

--- a/tests/area_tests.rs
+++ b/tests/area_tests.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 mod area_tests {
-    use quadtree_rs::area::{Area, AreaBuilder};
+    use quadtree_rs::area::{
+        Area,
+        AreaBuilder,
+    };
 
     mod builder {
         use super::*;

--- a/tests/iterator_tests.rs
+++ b/tests/iterator_tests.rs
@@ -16,9 +16,10 @@ mod util; // For unordered_elements_are.
 
 // For testing .iter(), .iter_mut(), .regions(), .values(), .values_mut().
 mod iterator_tests {
-    use {
-        crate::util::unordered_elements_are,
-        quadtree_rs::{entry::Entry, Quadtree},
+    use crate::util::unordered_elements_are;
+    use quadtree_rs::{
+        entry::Entry,
+        Quadtree,
     };
 
     fn mk_quadtree_for_iter_tests() -> Quadtree<i32, i8> {

--- a/tests/query_tests.rs
+++ b/tests/query_tests.rs
@@ -16,7 +16,8 @@ mod util; // For unordered_elements_are.
 
 // For testing .query(), .modify().
 mod query_tests {
-    use {crate::util::unordered_elements_are, quadtree_rs::Quadtree};
+    use crate::util::unordered_elements_are;
+    use quadtree_rs::Quadtree;
 
     #[test]
     fn query_empty() {

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,7 +1,14 @@
-use {
-    num::{cast::FromPrimitive, PrimInt},
-    quadtree_rs::area::AreaBuilder,
-    std::{collections::HashSet, default::Default, fmt::Debug, hash::Hash, iter::FromIterator},
+use num::{
+    cast::FromPrimitive,
+    PrimInt,
+};
+use quadtree_rs::area::AreaBuilder;
+use std::{
+    collections::HashSet,
+    default::Default,
+    fmt::Debug,
+    hash::Hash,
+    iter::FromIterator,
 };
 
 // Inspired by google/googletest's UnorderedElementsAre().


### PR DESCRIPTION
I used the following non-standard `rustfmt` options:

```toml
imports_layout = "Vertical"
imports_granularity = "Crate"
```

In my opinion they provide the most readable and editable imports layout possible.