### PR TITLE
Add optional Bevy support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,11 @@ maintenance = { status = "actively-developed" }
 num = "0.2"
 derive_builder = "0.7"
 serde = { version = "1.0.152", features = ["derive"], optional=true}
+bevy = { version = "0.12.1", optional = true }
 
 [features]
 serde = ["dep:serde"]
+bevy = ["dep:bevy"]
 
 
 # Run cargo tests and cargo-clippy as a precommit-hook, per the example in

--- a/src/quadtree.rs
+++ b/src/quadtree.rs
@@ -75,6 +75,7 @@ use std::{
 /// [`.delete()`]: #method.delete
 // TODO(ambuc): Implement `.delete_by(anchor, dimensions, fn)`: `.retain()` is the inverse.
 // TODO(ambuc): Implement `FromIterator<(K, V)>` for `Quadtree`.
+#[cfg_attr(feature = "bevy", derive(bevy::prelude::Resource))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq)]
 pub struct Quadtree<U, V>


### PR DESCRIPTION
Google CLA has been signed.

Enable user to insert Quadtree as a resource into their bevy application. E.g. 

```rust
fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .insert_resource(Quadtree::<u32, Entity>::new(8))
        .add_systems(Startup, setup)
        .add_systems(Update, update_quadtree)
        .run();
}

fn update_quadtree(
    mut quadtree: ResMut<Quadtree<u32, Entity>>,
    mut parent_query: Query<(Entity, &Children)>,
    mut transform_query: Query<&mut Transform>,
) {
    quadtree.contains(...);
}

```